### PR TITLE
Kotlin 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@ buildscript {
 }
 
 plugins {
-  kotlin("multiplatform") version "2.0.21" apply false
-  kotlin("jvm") version "2.0.21" apply false
+  kotlin("multiplatform") version "2.1.0" apply false
+  kotlin("jvm") version "2.1.0" apply false
   id("org.jetbrains.dokka") version "1.9.20"
   id("com.github.gmazzo.buildconfig") version "5.3.5"
   id("com.vanniktech.maven.publish.base") version "0.30.0"

--- a/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/PiecemealFirStatusTransformerExtension.kt
+++ b/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/PiecemealFirStatusTransformerExtension.kt
@@ -33,7 +33,7 @@ class PiecemealFirStatusTransformerExtension(
 ) : FirStatusTransformerExtension(session) {
   override fun needTransformStatus(declaration: FirDeclaration): Boolean {
     if (declaration is FirConstructor && declaration.isPrimary) {
-      val containingClass = declaration.getContainingClass(session)
+      val containingClass = declaration.getContainingClass()
       val annotation = containingClass?.getAnnotationByClassId(Piecemeal.ANNOTATION_CLASS_ID, session)
       return annotation != null
     }

--- a/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
+++ b/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
@@ -61,7 +61,7 @@ fun fun1Ext(
     session = session,
     typeArguments = arrayOf(
       receiver.constructStarProjectedType(),
-      session.builtinTypes.unitType.type,
+      session.builtinTypes.unitType.coneType,
     )
   ).withAttributes(ConeAttributes.create(listOf(CompilerConeAttributes.ExtensionFunctionType)))
 }
@@ -135,7 +135,7 @@ fun FirExtension.createPropertyBuilderValue(
     owner = builderClassSymbol,
     key = Piecemeal.Key,
     name = callableId.callableName,
-    returnType = parameter.resolvedReturnType.withNullability(ConeNullability.NULLABLE, session.typeContext),
+    returnType = parameter.resolvedReturnType.withNullability(nullable = true, session.typeContext),
     isVal = false
   )
 

--- a/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/ir/PiecemealBuilderGenerator.kt
+++ b/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/ir/PiecemealBuilderGenerator.kt
@@ -198,7 +198,6 @@ class PiecemealBuilderGenerator(
         context.irBuiltIns.anyType,
         anySymbol,
         typeArgumentsCount = 0,
-        valueArgumentsCount = 0
       )
       +IrInstanceInitializerCallImpl(
         UNDEFINED_OFFSET, UNDEFINED_OFFSET,


### PR DESCRIPTION
IDEA 2024.3.1.1 was throwing a diagnostic error when it hit `getContainingClass(session)` in FIR. That function's signature changed in 2.1.0 and the bump seems to make the IDE happy.