### PR TITLE
Apply piecemeal dependency using Gradle Plugin

### DIFF
--- a/piecemeal-gradle/build.gradle.kts
+++ b/piecemeal-gradle/build.gradle.kts
@@ -41,9 +41,8 @@ buildConfig {
   buildConfigField("String", "KOTLIN_PLUGIN_VERSION", "\"${pluginProject.version}\"")
 
   val libraryProject = project(":piecemeal")
-  buildConfigField("String", "SUPPORT_LIBRARY_GROUP", "\"${libraryProject.group}\"")
-  buildConfigField("String", "SUPPORT_LIBRARY_NAME", "\"${libraryProject.name}\"")
-  buildConfigField("String", "SUPPORT_LIBRARY_VERSION", "\"${libraryProject.version}\"")
+  val libraryCoordinates = "${libraryProject.group}:${libraryProject.name}:${libraryProject.version}"
+  buildConfigField("String", "SUPPORT_LIBRARY_COORDINATES", "\"$libraryCoordinates\"")
 }
 
 gradlePlugin {

--- a/piecemeal-gradle/src/main/kotlin/dev/bnorm/piecemeal/PiecemealGradlePlugin.kt
+++ b/piecemeal-gradle/src/main/kotlin/dev/bnorm/piecemeal/PiecemealGradlePlugin.kt
@@ -16,6 +16,7 @@
 
 package dev.bnorm.piecemeal
 
+import dev.bnorm.piecemeal.BuildConfig.SUPPORT_LIBRARY_COORDINATES
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME
 import org.gradle.api.provider.Provider
@@ -36,14 +37,14 @@ class PiecemealGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val kotlin = target.extensions.getByName("kotlin") as KotlinSourceSetContainer
         kotlin.sourceSets.getByName(COMMON_MAIN_SOURCE_SET_NAME) { sourceSet ->
           sourceSet.dependencies {
-            implementation(BuildConfig.annotationsDependency)
+            implementation(SUPPORT_LIBRARY_COORDINATES)
           }
         }
       } else {
         if (target.plugins.hasPlugin("org.gradle.java-test-fixtures")) {
-          target.dependencies.add("testFixturesImplementation", BuildConfig.annotationsDependency)
+          target.dependencies.add("testFixturesImplementation", SUPPORT_LIBRARY_COORDINATES)
         }
-        target.dependencies.add(IMPLEMENTATION_CONFIGURATION_NAME, BuildConfig.annotationsDependency)
+        target.dependencies.add(IMPLEMENTATION_CONFIGURATION_NAME, SUPPORT_LIBRARY_COORDINATES)
       }
     }
   }
@@ -73,7 +74,4 @@ class PiecemealGradlePlugin : KotlinCompilerPluginSupportPlugin {
       )
     }
   }
-
-  private val BuildConfig.annotationsDependency: String
-    get() = "$SUPPORT_LIBRARY_GROUP:$SUPPORT_LIBRARY_NAME:$SUPPORT_LIBRARY_VERSION"
 }

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/build.gradle.kts
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/build.gradle.kts
@@ -1,0 +1,31 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  kotlin("jvm")
+  `java-test-fixtures`
+  id("dev.bnorm.piecemeal")
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_1_8
+  }
+}
+
+dependencies {
+  implementation(kotlin("test"))
+}
+
+tasks.withType<Test>().configureEach {
+  testLogging {
+    events = setOf(TestLogEvent.STARTED, TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED)
+    exceptionFormat = TestExceptionFormat.FULL
+  }
+}

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/settings.gradle.kts
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+  repositories {
+    maven("$rootDir/../../../../../build/testMaven")
+    mavenCentral()
+    google()
+  }
+  plugins {
+    kotlin("jvm") version "${extra.properties["kotlinVersion"]}"
+    id("dev.bnorm.piecemeal") version "${extra.properties["piecemealVersion"]}"
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    maven("$rootDir/../../../../../build/testMaven")
+    mavenCentral()
+    google()
+  }
+}

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/src/main/java/Person.kt
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/src/main/java/Person.kt
@@ -1,0 +1,12 @@
+import dev.bnorm.piecemeal.Piecemeal
+
+@Piecemeal
+class Person(
+  val name: String,
+  val nickname: String? = name,
+  val age: Int = 0,
+) {
+  override fun toString(): String {
+    return "Person{name=$name, nickname=$nickname, age=$age}"
+  }
+}

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/src/test/java/PersonTest.kt
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/src/test/java/PersonTest.kt
@@ -1,0 +1,20 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PersonTest {
+  @Test
+  fun testApplyBuilder() {
+    val person = Person.Builder().apply {
+      name = "Sam"
+    }.build()
+    assertEquals(person.toString(), "Person{name=Sam, nickname=Sam, age=0}")
+  }
+
+  @Test
+  fun testCompanionBuild() {
+    val person = Person.build {
+      name = "Sam"
+    }
+    assertEquals(person.toString(), "Person{name=Sam, nickname=Sam, age=0}")
+  }
+}

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/src/test/java/SimpsonTest.kt
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/src/test/java/SimpsonTest.kt
@@ -1,0 +1,21 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SimpsonTest {
+  @Test
+  fun testApplyBuilder() {
+    val simpson = Simpson.Builder().apply {
+      firstName = "Homer"
+      lastName = "Simpson"
+    }.build()
+    assertEquals(simpson.toString(), "Simpson{firstName=Homer, lastName=Simpson}")
+  }
+
+  @Test
+  fun testCompanionBuild() {
+    val person = Simpson.build {
+      firstName = "Marjorie"
+    }
+    assertEquals(person.toString(), "Simpson{firstName=Marjorie, lastName=Simpson}")
+  }
+}

--- a/piecemeal-gradle/src/test/projects/java-test-fixtures/src/testFixtures/java/Simpson.kt
+++ b/piecemeal-gradle/src/test/projects/java-test-fixtures/src/testFixtures/java/Simpson.kt
@@ -1,0 +1,11 @@
+import dev.bnorm.piecemeal.Piecemeal
+
+@Piecemeal
+class Simpson(
+  val firstName: String,
+  val lastName: String = "Simpson",
+) {
+  override fun toString(): String {
+    return "Simpson{firstName=$firstName, lastName=$lastName}"
+  }
+}

--- a/piecemeal-gradle/src/test/projects/jvm/build.gradle.kts
+++ b/piecemeal-gradle/src/test/projects/jvm/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  kotlin("jvm")
+  id("dev.bnorm.piecemeal")
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_1_8
+  }
+}
+
+dependencies {
+  implementation(kotlin("test"))
+}
+
+tasks.withType<Test>().configureEach {
+  testLogging {
+    events = setOf(TestLogEvent.STARTED, TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED)
+    exceptionFormat = TestExceptionFormat.FULL
+  }
+}

--- a/piecemeal-gradle/src/test/projects/jvm/settings.gradle.kts
+++ b/piecemeal-gradle/src/test/projects/jvm/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+  repositories {
+    maven("$rootDir/../../../../../build/testMaven")
+    mavenCentral()
+    google()
+  }
+  plugins {
+    kotlin("jvm") version "${extra.properties["kotlinVersion"]}"
+    id("dev.bnorm.piecemeal") version "${extra.properties["piecemealVersion"]}"
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    maven("$rootDir/../../../../../build/testMaven")
+    mavenCentral()
+    google()
+  }
+}

--- a/piecemeal-gradle/src/test/projects/jvm/src/main/java/Person.kt
+++ b/piecemeal-gradle/src/test/projects/jvm/src/main/java/Person.kt
@@ -1,0 +1,12 @@
+import dev.bnorm.piecemeal.Piecemeal
+
+@Piecemeal
+class Person(
+  val name: String,
+  val nickname: String? = name,
+  val age: Int = 0,
+) {
+  override fun toString(): String {
+    return "Person{name=$name, nickname=$nickname, age=$age}"
+  }
+}

--- a/piecemeal-gradle/src/test/projects/jvm/src/test/java/PersonTest.kt
+++ b/piecemeal-gradle/src/test/projects/jvm/src/test/java/PersonTest.kt
@@ -1,0 +1,20 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PersonTest {
+  @Test
+  fun testApplyBuilder() {
+    val person = Person.Builder().apply {
+      name = "Sam"
+    }.build()
+    assertEquals(person.toString(), "Person{name=Sam, nickname=Sam, age=0}")
+  }
+
+  @Test
+  fun testCompanionBuild() {
+    val person = Person.build {
+      name = "Sam"
+    }
+    assertEquals(person.toString(), "Person{name=Sam, nickname=Sam, age=0}")
+  }
+}


### PR DESCRIPTION
The current implementation of applying the “piecemeal” library via the Gradle Plugin does not work for multiplatform projects. To automate the process and reduce boilerplate associated with this dependency, the Gradle Plugin has been updated.

The new implementation is taken from the [PokoGradlePlugin](https://github.com/drewhamilton/Poko/blob/main/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt). It now properly supports the kotlin-multiplatform plugin and the java-test-fixtures plugin.