### PR TITLE
Inline the `build { }` function

### DIFF
--- a/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
+++ b/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
@@ -18,7 +18,12 @@ package dev.bnorm.piecemeal.plugin.fir
 
 import dev.bnorm.piecemeal.plugin.Piecemeal
 import dev.bnorm.piecemeal.plugin.toJavaSetter
+import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
+import org.jetbrains.kotlin.contracts.description.KtValueParameterReference
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.contracts.builder.buildEffectDeclaration
+import org.jetbrains.kotlin.fir.contracts.builder.buildResolvedContractDescription
+import org.jetbrains.kotlin.fir.contracts.description.ConeCallsEffectDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.extensions.ExperimentalTopLevelDeclarationsGenerationApi
@@ -161,5 +166,11 @@ fun FirExtension.createFunPiecemealDsl(
       isInline = true
     }
     valueParameter(Name.identifier("builder"), builderType)
+  }.apply {
+    replaceContractDescription(buildResolvedContractDescription {
+      effects += buildEffectDeclaration {
+        effect = ConeCallsEffectDeclaration(KtValueParameterReference(0, "builder"), EventOccurrencesRange.EXACTLY_ONCE)
+      }
+    })
   }
 }

--- a/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
+++ b/piecemeal-plugin/src/main/kotlin/dev/bnorm/piecemeal/plugin/fir/factory.kt
@@ -157,6 +157,9 @@ fun FirExtension.createFunPiecemealDsl(
     name = callableId.callableName,
     returnType = piecemealClassSymbol.constructStarProjectedType(),
   ) {
+    status {
+      isInline = true
+    }
     valueParameter(Name.identifier("builder"), builderType)
   }
 }

--- a/piecemeal-test/src/test/data/box/Builder.fir.ir.txt
+++ b/piecemeal-test/src/test/data/box/Builder.fir.ir.txt
@@ -219,7 +219,7 @@ FILE fqName:<root> fileName:/Builder.kt
         overridden:
           public open fun toString (): kotlin.String declared in kotlin.Any
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:build visibility:public modality:FINAL <> ($this:<root>.Person.Companion, builder:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>) returnType:<root>.Person
+      FUN GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:build visibility:public modality:FINAL <> ($this:<root>.Person.Companion, builder:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>) returnType:<root>.Person [inline]
         $this: VALUE_PARAMETER name:<this> type:<root>.Person.Companion
         VALUE_PARAMETER GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:builder index:0 type:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>
         BLOCK_BODY

--- a/piecemeal-test/src/test/data/box/BuilderWithSetters.fir.ir.txt
+++ b/piecemeal-test/src/test/data/box/BuilderWithSetters.fir.ir.txt
@@ -246,7 +246,7 @@ FILE fqName:<root> fileName:/BuilderWithSetters.kt
         overridden:
           public open fun toString (): kotlin.String declared in kotlin.Any
         $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:build visibility:public modality:FINAL <> ($this:<root>.Person.Companion, builder:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>) returnType:<root>.Person
+      FUN GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:build visibility:public modality:FINAL <> ($this:<root>.Person.Companion, builder:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>) returnType:<root>.Person [inline]
         $this: VALUE_PARAMETER name:<this> type:<root>.Person.Companion
         VALUE_PARAMETER GENERATED[dev.bnorm.piecemeal.plugin.Piecemeal.Key] name:builder index:0 type:@[ExtensionFunctionType] kotlin.Function1<<root>.Person.Builder, kotlin.Unit>
         BLOCK_BODY

--- a/piecemeal-test/src/test/data/box/InlineBuild.kt
+++ b/piecemeal-test/src/test/data/box/InlineBuild.kt
@@ -1,0 +1,24 @@
+import dev.bnorm.piecemeal.Piecemeal
+import kotlin.test.assertEquals
+
+@Piecemeal
+class Test(
+  val value: Int = 0,
+)
+
+fun box(): String {
+  val x: Int
+  Test.build {
+    x = 0
+  }
+  assertEquals(x, 0)
+
+  val list = sequence {
+    Test.build {
+      yield(0)
+    }
+  }.toList()
+  assertEquals(list, listOf(0))
+
+  return "OK"
+}

--- a/piecemeal-test/src/test/data/diagnostic/BuilderResolved.fir.txt
+++ b/piecemeal-test/src/test/data/diagnostic/BuilderResolved.fir.txt
@@ -16,7 +16,7 @@ FILE: BuilderResolved.kt
         public final fun newBuilder(): R|Person.Builder|
 
         public final companion object Companion : R|kotlin/Any| {
-            public final fun build(builder: R|Person.Builder.() -> kotlin/Unit|): R|Person|
+            public final inline fun build(builder: R|Person.Builder.() -> kotlin/Unit|): R|Person|
 
             private constructor(): R|Person.Companion| {
                 super<R|kotlin/Any|>()
@@ -60,7 +60,7 @@ FILE: BuilderResolved.kt
         ).R|/Person.Builder.build|()
     }
     public final fun person3(): R|Person| {
-        ^person3 Q|Person|.R|/Person.Companion.build|(<L> = build@fun R|Person.Builder|.<anonymous>(): R|kotlin/Unit| <inline=NoInline>  {
+        ^person3 Q|Person|.R|/Person.Companion.build|(<L> = build@fun R|Person.Builder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
             this@R|special/anonymous|.R|/Person.Builder.name| = String(John)
         }
         )

--- a/piecemeal-test/src/test/data/diagnostic/BuilderResolved.fir.txt
+++ b/piecemeal-test/src/test/data/diagnostic/BuilderResolved.fir.txt
@@ -17,6 +17,11 @@ FILE: BuilderResolved.kt
 
         public final companion object Companion : R|kotlin/Any| {
             public final inline fun build(builder: R|Person.Builder.() -> kotlin/Unit|): R|Person|
+                [R|Contract description]
+                 <
+                    CallsInPlace(builder, EXACTLY_ONCE)
+                >
+
 
             private constructor(): R|Person.Companion| {
                 super<R|kotlin/Any|>()
@@ -60,7 +65,7 @@ FILE: BuilderResolved.kt
         ).R|/Person.Builder.build|()
     }
     public final fun person3(): R|Person| {
-        ^person3 Q|Person|.R|/Person.Companion.build|(<L> = build@fun R|Person.Builder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+        ^person3 Q|Person|.R|/Person.Companion.build|(<L> = build@fun R|Person.Builder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=EXACTLY_ONCE>  {
             this@R|special/anonymous|.R|/Person.Builder.name| = String(John)
         }
         )

--- a/piecemeal-test/src/test/java/dev/bnorm/piecemeal/BoxTestGenerated.java
+++ b/piecemeal-test/src/test/java/dev/bnorm/piecemeal/BoxTestGenerated.java
@@ -38,4 +38,10 @@ public class BoxTestGenerated extends AbstractBoxTest {
   public void testBuilderWithSetters() {
     runTest("piecemeal-test/src/test/data/box/BuilderWithSetters.kt");
   }
+
+  @Test
+  @TestMetadata("InlineBuild.kt")
+  public void testInlineBuild() {
+    runTest("piecemeal-test/src/test/data/box/InlineBuild.kt");
+  }
 }


### PR DESCRIPTION
The current implementation of the `build` function doesn't allow to use a compose functions within it. The `Builder` class is an alternative, but it doesn't align with the idiomatic use of Kotlin.

I propose modifying the build function to an _inline function_. This change would enable to use compose functions within the `build` function.

Since the function doesn't contain a significant amount of code, I think it can be safely inlined.

What do you think about this change?